### PR TITLE
Add WHERE clause to crime layer query

### DIFF
--- a/server/repositories/layer_strategy.py
+++ b/server/repositories/layer_strategy.py
@@ -60,7 +60,8 @@ class CrimeLayerStrategy(LayerStrategy):
         # query building
         query = Query \
             .from_(nypd_incidents) \
-            .select(nypd_incidents.latitude, nypd_incidents.longitude)
+            .select(nypd_incidents.latitude, nypd_incidents.longitude) \
+            .where(nypd_incidents.crime_type != 'OFF. AGNST PUB ORD SENSBLTY &')
 
         return query.get_sql()
 

--- a/test/repositories/test_layer_strategy.py
+++ b/test/repositories/test_layer_strategy.py
@@ -11,6 +11,6 @@ class TestLayerStrategy(TestCase):
         self.assertEqual(expected_query, actual_query)
 
     def test_crime_layer_build_get_all_query(self):
-        expected_query = 'SELECT "latitude","longitude" FROM "nypd_incidents"'
+        expected_query = 'SELECT "latitude","longitude" FROM "nypd_incidents" WHERE "crime_type"<>\'OFF. AGNST PUB ORD SENSBLTY &\''
         actual_query = CrimeLayerStrategy().build_get_all_query()
         self.assertEqual(expected_query, actual_query)


### PR DESCRIPTION
Add missing WHERE clause for `crime layer`. 
I just excluded the value that is used for the `complaints layer.`