### PR TITLE
Improved swagger documentation for layer operations and removed unused id fields

### DIFF
--- a/server/models/layer_entry.py
+++ b/server/models/layer_entry.py
@@ -14,28 +14,23 @@ class LayerEntry(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, id: int=None, latitude: float=None, longitude: float=None):  # noqa: E501
+    def __init__(self, latitude: float=None, longitude: float=None):
         """LayerEntry - a model defined in Swagger
 
-        :param id: The id of this LayerEntry.  # noqa: E501
-        :type id: int
-        :param latitude: The latitude of this LayerEntry.  # noqa: E501
+        :param latitude: The latitude of this LayerEntry.
         :type latitude: float
-        :param longitude: The longitude of this LayerEntry.  # noqa: E501
+        :param longitude: The longitude of this LayerEntry.
         :type longitude: float
         """
         self.swagger_types = {
-            'id': int,
             'latitude': float,
             'longitude': float
         }
 
         self.attribute_map = {
-            'id': 'id',
             'latitude': 'latitude',
             'longitude': 'longitude'
         }
-        self._id = id
         self._latitude = latitude
         self._longitude = longitude
 
@@ -45,31 +40,10 @@ class LayerEntry(Model):
 
         :param dikt: A dict.
         :type: dict
-        :return: The LayerEntry of this LayerEntry.  # noqa: E501
+        :return: The LayerEntry of this LayerEntry.
         :rtype: LayerEntry
         """
         return util.deserialize_model(dikt, cls)
-
-    @property
-    def id(self) -> int:
-        """Gets the id of this LayerEntry.
-
-
-        :return: The id of this LayerEntry.
-        :rtype: int
-        """
-        return self._id
-
-    @id.setter
-    def id(self, id: int):
-        """Sets the id of this LayerEntry.
-
-
-        :param id: The id of this LayerEntry.
-        :type id: int
-        """
-
-        self._id = id
 
     @property
     def latitude(self) -> float:

--- a/server/swagger/swagger.yaml
+++ b/server/swagger/swagger.yaml
@@ -31,6 +31,7 @@ paths:
         explode: false
         schema:
           type: integer
+          example: 2539
       responses:
         "200":
           description: Successful operation
@@ -232,6 +233,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Layer'
+              example:
+                entries:
+                  - latitude: 6.02745618307040320615897144307382404804229736328125
+                    longitude: 1.46581298050294517310021547018550336360931396484375
+                  - latitude: 6.02745618307040320615897144307382404804229736328125
+                    longitude: 1.46581298050294517310021547018550336360931396484375
+                type: CRIME_LAYER
         "400":
           description: Invalid ID supplied
         "500":
@@ -251,6 +259,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Layer'
+              example:
+                entries:
+                  - latitude: 6.02745618307040320615897144307382404804229736328125
+                    longitude: 1.46581298050294517310021547018550336360931396484375
+                  - latitude: 6.02745618307040320615897144307382404804229736328125
+                    longitude: 1.46581298050294517310021547018550336360931396484375
+                type: COMPLAINT_LAYER
         "500":
           description: Internal Server Error
       x-openapi-router-controller: server.controllers.layers_controller
@@ -268,6 +283,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Layer'
+              example:
+                entries:
+                  - latitude: 6.02745618307040320615897144307382404804229736328125
+                    longitude: 1.46581298050294517310021547018550336360931396484375
+                  - latitude: 6.02745618307040320615897144307382404804229736328125
+                    longitude: 1.46581298050294517310021547018550336360931396484375
+                type: HEALTH_LAYER
         "500":
           description: Internal Server Error
       x-openapi-router-controller: server.controllers.layers_controller
@@ -470,9 +492,9 @@ components:
         type:
           type: string
           enum:
-          - crime
-          - complaints
-          - health
+          - CRIME_LAYER
+          - COMPLAINT_LAYER
+          - HEALTH_LAYER
         entries:
           type: array
           items:
@@ -480,23 +502,17 @@ components:
       example:
         entries:
         - latitude: 6.02745618307040320615897144307382404804229736328125
-          id: 0
           longitude: 1.46581298050294517310021547018550336360931396484375
         - latitude: 6.02745618307040320615897144307382404804229736328125
-          id: 0
           longitude: 1.46581298050294517310021547018550336360931396484375
-        type: crime
+        type: CRIME_LAYER
     LayerEntry:
       type: object
       properties:
-        id:
-          type: integer
         latitude:
           type: number
         longitude:
           type: number
       example:
         latitude: 6.02745618307040320615897144307382404804229736328125
-        id: 0
         longitude: 1.46581298050294517310021547018550336360931396484375
-


### PR DESCRIPTION
We still had ID fields for `LayerEntry ` objects which we don't need, this PR removes those.