### PR TITLE
Change docker image to slim because of compatibility issues with sklearn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.9-alpine
+FROM python:3.9-slim
 
 ADD . /bnbexplorer-backend/
 
 WORKDIR /bnbexplorer-backend
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --quiet --no-cache-dir -r requirements.txt
 
 CMD ["python3", "-m", "server"]


### PR DESCRIPTION
Docker image build failed with the added dependency of sklearn in my last PR, as it had issues with installing the required libraries.
Tbh, I'm not yet entirely sure why, but found that changing to a `slim` image will fix the build issue. 🤔 