### PR TITLE
Travis build error fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ connexion[swagger-ui]
 connexion == 2.6.0
 python_dateutil == 2.6.0
 setuptools >= 21.0.0
+flask==1.1.*
 Flask-Cors==3.0.10
 python-dotenv==0.16.0
 swagger-ui-bundle==0.0.8


### PR DESCRIPTION
Flask just dropped a new [release](https://pypi.org/project/Flask/#history) which breaks our build on travis. 
I noticed that since we do not specifically set the required version for flask in our requirements.txt file, it automatically downloads the latest version (2.0.0) which breaks our build. So to solve this, we fix the flask version to 1.1.*, which worked for every build so far.

I hope this solves the issue, because I can still successfully build the docker image locally withouth the fix.