### PR TITLE
Minor coverage tracking improvements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,13 +1,16 @@
 [run]
 branch = True
 omit =
-    /test/*
+    */test/*
     */migrations/*
-    *__init__.py*
-    *__main__.py*
+    */models/*
+    */utils/*
+    */__init__.py
+    */__main__.py
 
 [report]
 exclude_lines =
     # Ignore imports
     from
     import
+    pass

--- a/server/repositories/__init__.py
+++ b/server/repositories/__init__.py
@@ -1,2 +1,0 @@
-import os
-import sqlite3

--- a/server/repositories/base_repository.py
+++ b/server/repositories/base_repository.py
@@ -24,19 +24,18 @@ class Repository(object):
         :param room_type: room_type string to map
         :return: numerical encoding of room_type
         """
-        try:
-            if room_type is not None:
-                if room_type == 'Private room':
-                    return 1
-                elif room_type == 'Entire home/apt':
-                    return 2
-                elif room_type == 'Shared Room':
-                    return 3
-                else:
-                    return 0
+        if room_type is not None:
+            if room_type == 'Private room':
+                return 1
+            elif room_type == 'Entire home/apt':
+                return 2
+            elif room_type == 'Shared Room':
+                return 3
             else:
+                # fallback
                 return 0
-        except:
+        else:
+            # fallback
             return 0
 
     def execute_select_query(self, query):

--- a/test/repositories/test_base_repository.py
+++ b/test/repositories/test_base_repository.py
@@ -5,6 +5,11 @@ from server.repositories.base_repository import Repository
 
 class BaseRepositoryTest(TestCase):
 
+    def test_base_repository_methods_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            # method is not implemented
+            Repository().map_result(None)
+
     def test_map_rt_private_room(self):
         input = 'Private room'
         expectation = 1


### PR DESCRIPTION
Exclude `/models` and `/utils` directories from coverage report, as they contain autogenerated (swagger) code and minor coverage improvements. We should have full coverage now for the code that matters. 🤔 